### PR TITLE
Feat #1 (landing-ui): add random leader landing page and slug-based navigation

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,0 +1,5 @@
+function LeaderPage() {
+  return <div>LeaderPage</div>;
+}
+
+export default LeaderPage;

--- a/src/app/components/Content.tsx
+++ b/src/app/components/Content.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { getRandomThunk } from "@/features/app/leader/redux/thunks/get_random";
+import { useAppDispatch, useAppSelector } from "@/shared/redux/hooks";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect } from "react";
+
+function Content() {
+  const dispatch = useAppDispatch();
+  const { leader, isLoading, error } = useAppSelector(
+    (state) => state.leaderReducer
+  );
+
+  useEffect(() => {
+    if (!leader && !isLoading) {
+      dispatch(getRandomThunk());
+    }
+  }, [leader, isLoading, error, dispatch]);
+
+  return (
+    <main className="flex-1 flex">
+      {isLoading && (
+        <div className="flex-1 flex items-center justify-center text-white/60">
+          Loading leader...
+        </div>
+      )}
+
+      {error && (
+        <div className="flex-1 flex items-center justify-center text-red-400">
+          Error loading leader
+        </div>
+      )}
+
+      {leader && (
+        <>
+          {/* ---------- left side ---------- */}
+          <div className="w-1/2 px-16 flex flex-col justify-center">
+            {/* SEARCH */}
+            <input
+              placeholder="Search leader..."
+              className="mb-8 bg-white/10 border border-white/20 px-4 py-2 rounded-md text-sm focus:outline-none"
+            />
+
+            {/* NAME */}
+            <h1 className="text-5xl font-bold leading-tight">
+              {leader.full_name}
+            </h1>
+
+            {/* NICKNAME */}
+            {leader.nickname && (
+              <p className="mt-2 text-xl text-white/60">“{leader.nickname}”</p>
+            )}
+
+            {/* PHRASE */}
+            {leader.phrase && (
+              <p className="mt-6 italic text-white/80">{leader.phrase}</p>
+            )}
+
+            {/* BIO */}
+            <p className="mt-6 text-sm leading-relaxed text-white/70 max-w-xl">
+              {leader.biography}
+            </p>
+
+            {/* ACTION */}
+            <div className="mt-10">
+              <Link href={`/${leader.slug}`}>
+                <button
+                  className="px-6 py-3 rounded-lg bg-white text-black text-sm font-semibold
+                             hover:bg-white/90 transition"
+                >
+                  View more about the leader →
+                </button>
+              </Link>
+            </div>
+          </div>
+
+          {/* ---------- right side ---------- */}
+          <div className="w-1/2 relative pt-10">
+            {leader.banner_url && (
+              <Image
+                src={leader.banner_url}
+                alt={`${leader.full_name} banner`}
+                fill
+                className="object-cover object-top"
+                unoptimized
+              />
+            )}
+            {/* OVERLAY */}
+            <div className="absolute inset-0 bg-linear-to-l from-black/30 to-black" />
+          </div>
+        </>
+      )}
+    </main>
+  );
+}
+
+export default Content;

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useAppSelector } from "@/shared/redux/hooks";
+
+export default function Navbar() {
+  const { auth } = useAppSelector((state) => state.authReducer);
+  const router = useRouter();
+
+  return (
+    <nav className="w-full bg-black px-6 py-2 flex items-center justify-between border-b border-white/10">
+      <div
+        className="text-lg font-semibold cursor-pointer"
+        onClick={() => router.push("/")}
+      >
+        Lideres
+      </div>
+
+      {auth?.user ? (
+        <div className="flex items-center gap-3">
+          {auth.user.img_url && (
+            <Image
+              src={auth.user.img_url}
+              width={32}
+              height={32}
+              alt="User avatar"
+              className="rounded-full border border-white/20 object-cover"
+              unoptimized
+            />
+          )}
+
+          <span className="text-sm opacity-90">
+            {auth.user.email}
+          </span>
+
+          <button
+            onClick={() => router.push("/home")}
+            className="px-4 py-1 bg-white text-black rounded-md text-sm font-medium hover:bg-gray-100 transition"
+          >
+            Go to Home
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => router.push("/auth/sign-in")}
+          className="px-4 py-1 bg-white text-black rounded-md text-sm font-medium hover:bg-gray-100 transition"
+        >
+          Sign in
+        </button>
+      )}
+    </nav>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,62 +1,13 @@
 "use client";
 
-import { useAppSelector } from "@/shared/redux/hooks";
-import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import Navbar from "@/app/components/Navbar";
+import Content from "./components/Content";
 
 function LandingPage() {
-  const { status, isLoading, error, auth } = useAppSelector(
-    (state) => state.authReducer
-  );
-
-  const router = useRouter();
-
-  useEffect(() => {}, [status, isLoading, error, auth]);
-
   return (
-    <div className="min-h-screen flex flex-col bg-white">
-      {/* NAVBAR */}
-      <nav className="w-full bg-black text-white px-6 py-2 flex items-center justify-between shadow-md">
-        <div
-          className="text-lg font-semibold cursor-pointer"
-          onClick={() => (window.location.href = "/")}
-        >
-          MyApp
-        </div>
-
-        {auth?.user ? (
-          <div className="flex items-center gap-3">
-            {auth.user.img_url && (
-              <Image
-                src={auth.user.img_url}
-                width={32}
-                height={32}
-                alt="User avatar"
-                className="rounded-full border border-white/20 object-cover"
-                unoptimized
-              />
-            )}
-
-            <span className="text-sm opacity-90">{auth.user.email}</span>
-
-            <button
-              onClick={() => router.push("/home")}
-              className="px-4 py-1 bg-white text-black rounded-md text-sm font-medium hover:bg-gray-100 transition"
-            >
-              Go to Home
-            </button>
-          </div>
-        ) : (
-          // If you are not authenticated
-          <button
-            onClick={() => (window.location.href = "/auth/sign-in")}
-            className="px-4 py-1 bg-white text-black rounded-md text-sm font-medium hover:bg-gray-100 transition"
-          >
-            Sign in
-          </button>
-        )}
-      </nav>
+    <div className="min-h-screen flex flex-col bg-black text-white">
+      <Navbar/>
+      <Content/>
     </div>
   );
 }

--- a/src/features/app/leader/api/get_random.ts
+++ b/src/features/app/leader/api/get_random.ts
@@ -1,0 +1,22 @@
+import { api } from "@/shared/api/axios_client";
+import { AxiosError } from "axios";
+import { Leader } from "../domain/domain";
+
+export async function getRandom(): Promise<Leader> {
+  try {
+    const resp = await api.get<Leader>("/leaders/random");
+
+    return resp.data;
+  } catch (err) {
+    const axiosError = err as AxiosError;
+
+    if (axiosError.response?.data) {
+      const backendError = axiosError.response.data as {
+        code: string;
+        msg: string;
+      };
+      throw new Error(backendError.msg);
+    }
+    throw err;
+  }
+}

--- a/src/features/app/leader/domain/domain.ts
+++ b/src/features/app/leader/domain/domain.ts
@@ -1,0 +1,27 @@
+export interface Leader {
+  id: string;
+  slug: string;
+  full_name: string;
+  nickname?: string;
+  phrase?: string;
+  biography: string;
+
+  avatar_url?: string;
+  banner_url?: string;
+
+  birth_date: string;
+  nationality: string;
+  gender: Gender;
+  ideology?: string;
+
+  facebook?: string;
+  instagram?: string;
+  twitter?: string;
+  youtube?: string;
+  linkedin?: string;
+  website?: string | null;
+
+  created_at: string;
+}
+
+export type Gender = "male" | "female" | "other";

--- a/src/features/app/leader/redux/slice.ts
+++ b/src/features/app/leader/redux/slice.ts
@@ -1,0 +1,27 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { initialState } from "./state";
+import { getRandomThunk } from "./thunks/get_random";
+
+const leaderSlice = createSlice({
+  name: "leader",
+  reducers: {},
+  initialState,
+  extraReducers: (builder) => {
+    builder
+      // Get leader random
+      .addCase(getRandomThunk.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(getRandomThunk.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.leader = action.payload;
+      })
+      .addCase(getRandomThunk.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.payload as Error;
+      });
+  },
+});
+export const {} = leaderSlice.actions;
+export default leaderSlice.reducer;

--- a/src/features/app/leader/redux/state.ts
+++ b/src/features/app/leader/redux/state.ts
@@ -1,0 +1,13 @@
+import { Leader } from "../domain/domain";
+
+export interface LeaderState {
+  leader: Leader | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export const initialState: LeaderState = {
+  leader: null,
+  isLoading: false,
+  error: null,
+};

--- a/src/features/app/leader/redux/thunks/get_random.ts
+++ b/src/features/app/leader/redux/thunks/get_random.ts
@@ -1,0 +1,19 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { Leader } from "../../domain/domain";
+import { getRandom } from "../../api/get_random";
+
+export const getRandomThunk = createAsyncThunk<Leader, void>(
+  "leader/getRandom",
+  async (_, { rejectWithValue }) => {
+    try {
+      const resp = await getRandom();
+      return resp;
+    } catch (err) {
+      if (err instanceof Error) {
+        return rejectWithValue({ message: err.message });
+      }
+
+      return rejectWithValue({ message: "Unexpected error occurred" });
+    }
+  }
+);

--- a/src/shared/redux/store.ts
+++ b/src/shared/redux/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "@/features/auth/redux/slice";
+import leaderReducer from "@/features/app/leader/redux/slice";
 
 export const store = configureStore({
   reducer: {
     authReducer: authReducer,
+    leaderReducer: leaderReducer,
   },
 });
 


### PR DESCRIPTION
### Tasks

- Fetch a random leader from the backend API
- Handle loading and error states
- Display leader main information on landing page
- Add CTA to view leader details
- Implement dynamic routing using leader slug
- Add leader detail page placeholder
- Integrate leader state into global store

<img width="1366" height="694" alt="image" src="https://github.com/user-attachments/assets/07c9197e-e106-42ab-9847-6674099979d8" />
<img width="1366" height="648" alt="image" src="https://github.com/user-attachments/assets/2cb0cee6-de37-4731-a427-f4fc7ec1e16c" />

Close #1 